### PR TITLE
v0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 USER $NB_USER
 RUN conda install --quiet --yes \
     'bash_kernel' \
+    'tiledb-py=0.6.*' \
     'bioconda::bcftools=1.10.*' \
     'bioconda::pybedtools=0.8.*' \
     'tiledb::libtiledbvcf=0.4.*' \
     'tiledb::tiledbvcf-py=0.4.*' \
-    'conda-forge::tiledb-py=0.6.*' \
     && conda clean --all -f -y
 
 RUN pip install git+https://github.com/TileDB-Inc/TileDB-Cloud-Py.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 USER $NB_USER
 RUN conda install --quiet --yes \
     'bash_kernel' \
-    'tiledb-py=0.6.*' \
     'bioconda::bcftools=1.10.*' \
     'bioconda::pybedtools=0.8.*' \
     'tiledb::libtiledbvcf=0.4.*' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN conda install --quiet --yes \
     'python=3.7.*' \
     'bioconda::bcftools=1.10.*' \
     'bioconda::pybedtools=0.8.*' \
-    'tiledb::libtiledbvcf=0.4.*' \
-    'tiledb::tiledbvcf-py=0.4.*' \
+    'tiledb::libtiledbvcf=0.5.*' \
+    'tiledb::tiledbvcf-py=0.5.*' \
     && conda clean --all -f -y
 
 RUN pip install git+https://github.com/TileDB-Inc/TileDB-Cloud-Py.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM jupyter/minimal-notebook:b90cce83f37b
 
+ENV AWS_EC2_METADATA_DISABLED true
+
 USER root
 RUN apt-get update && apt-get install --no-install-recommends -y \
     tree \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 USER $NB_USER
 RUN conda install --quiet --yes \
     'bash_kernel' \
-    'conda-forge::tiledb-py=0.6.*' \
     'bioconda::bcftools=1.10.*' \
     'bioconda::pybedtools=0.8.*' \
     'tiledb::libtiledbvcf=0.4.*' \
     'tiledb::tiledbvcf-py=0.4.*' \
+    'conda-forge::tiledb-py=0.6.*' \
     && conda clean --all -f -y
+
+RUN pip install git+https://github.com/TileDB-Inc/TileDB-Cloud-Py.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:latest
+FROM jupyter/minimal-notebook:b90cce83f37b
 
 USER root
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 USER $NB_USER
 RUN conda install --quiet --yes \
     'bash_kernel' \
+    'python=3.7.*' \
     'bioconda::bcftools=1.10.*' \
     'bioconda::pybedtools=0.8.*' \
     'tiledb::libtiledbvcf=0.4.*' \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,5 @@
 FROM aaronwolen/tiledbvcf-notebook:latest
+ARG BRANCH=master
 
 ENV AWS_EC2_METADATA_DISABLED true
 ENV TILEDBVCF_FORCE_EXTERNAL_HTSLIB=OFF
@@ -17,7 +18,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists*
 
 WORKDIR /tmp
-RUN git clone https://github.com/TileDB-Inc/TileDB-VCF.git
+RUN git clone -b ${BRANCH} https://github.com/TileDB-Inc/TileDB-VCF.git
 
 # Build library and CLI
 WORKDIR /tmp/TileDB-VCF/libtiledbvcf/build

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,36 @@
+FROM aaronwolen/tiledbvcf-notebook:latest
+
+ENV AWS_EC2_METADATA_DISABLED true
+ENV TILEDBVCF_FORCE_EXTERNAL_HTSLIB=OFF
+
+# Remove Conda versions
+RUN conda remove --quiet --yes \
+    'libtiledbvcf' \
+    'tiledbvcf-py' \
+    && conda clean --all -f -y
+
+USER root
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    cmake \
+    && apt-get clean \
+    && apt-get purge -y \
+    && rm -rf /var/lib/apt/lists*
+
+WORKDIR /tmp
+RUN git clone https://github.com/TileDB-Inc/TileDB-VCF.git
+
+# Build library and CLI
+WORKDIR /tmp/TileDB-VCF/libtiledbvcf/build
+RUN cmake .. -DFORCE_EXTERNAL_HTSLIB=OFF -DOVERRIDE_INSTALL_PREFIX=OFF -DCMAKE_INSTALL_PREFIX="${CONDA_DIR}"
+RUN make -j8
+RUN make install-libtiledbvcf
+
+# Build Python module
+WORKDIR /tmp/TileDB-VCF/apis/python
+RUN conda env update -n base -f conda-env.yml \
+    && conda clean -a -y
+RUN python setup.py install --libtiledbvcf=/opt/conda
+RUN rm -rf /tmp/tiledbvcf
+
+USER $NB_USER
+WORKDIR /home/jovyan

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Jupyter Notebook for TileDB-VCF Development
 
+## Tags
+
+The `-dev` suffix specifies the `Dockerfile-dev` image.
+
+* `stable`, `stable-dev`: most recent tagged released
+* `latest`, `latest-dev`: latest version of `dev` branch
+* `test`, `test-dev`: latest version of `dev` branch
+
 ## Stable
 
 Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jupyter Notebook for TileDB-VCF Development
 
+## Stable
+
 Build
 
 ```
@@ -14,4 +16,12 @@ docker run --rm \
   -v "$PWD":/home/jovyan/work \
   -e JUPYTER_ENABLE_LAB=yes \
   aaronwolen/tiledbvcf-notebook:latest
+```
+
+## Development
+
+A second image is included that builds the CLI and Python module directly from the GitHub repo.
+
+```
+docker build -f Dockerfile-dev -t aaronwolen/tiledbvcf-notebook:dev .
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ docker run --rm \
 
 A second image is included that builds the CLI and Python module directly from the GitHub repo.
 
+Available build args:
+* `BRANCH`: which TileDB-VCF git branch to clone (default: `master`)
+
 ```
 docker build -f Dockerfile-dev -t aaronwolen/tiledbvcf-notebook:dev .
 ```


### PR DESCRIPTION
- Pins `jupyter/minimal-notebook` image to `b90cce83f37b`
- Adds `Dockerfile-dev` that installs tiledbvcf-py from master branch
- Define docker tag scheme